### PR TITLE
Add .NET Core SHIORI prototype

### DIFF
--- a/MacUkagaka.SHIORI/AIServices/ChatGPTService.cs
+++ b/MacUkagaka.SHIORI/AIServices/ChatGPTService.cs
@@ -1,0 +1,40 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+namespace MacUkagaka.SHIORI.AIServices;
+
+public class ChatGPTService : IAIService
+{
+    private readonly string _apiKey;
+    private readonly string _model;
+
+    public ChatGPTService(string apiKey, string model)
+    {
+        _apiKey = apiKey;
+        _model = string.IsNullOrEmpty(model) ? "gpt-3.5-turbo" : model;
+    }
+
+    public async Task<string> GenerateResponseAsync(string prompt)
+    {
+        var endpoint = "https://api.openai.com/v1/chat/completions";
+        var obj = new
+        {
+            model = _model,
+            messages = new[] { new { role = "user", content = prompt } }
+        };
+        var json = JsonSerializer.Serialize(obj);
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        request.Headers.Add("Authorization", $"Bearer {_apiKey}");
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var client = new HttpClient();
+        var response = await client.SendAsync(request);
+        var str = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(str);
+        var content = doc.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message")
+            .GetProperty("content").GetString();
+        return content ?? str;
+    }
+}

--- a/MacUkagaka.SHIORI/AIServices/ClaudeService.cs
+++ b/MacUkagaka.SHIORI/AIServices/ClaudeService.cs
@@ -1,0 +1,41 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+namespace MacUkagaka.SHIORI.AIServices;
+
+public class ClaudeService : IAIService
+{
+    private readonly string _apiKey;
+    private readonly string _model;
+
+    public ClaudeService(string apiKey, string model)
+    {
+        _apiKey = apiKey;
+        _model = string.IsNullOrEmpty(model) ? "claude-instant-1" : model;
+    }
+
+    public async Task<string> GenerateResponseAsync(string prompt)
+    {
+        var endpoint = "https://api.anthropic.com/v1/complete";
+        var obj = new
+        {
+            prompt = prompt,
+            model = _model,
+            max_tokens_to_sample = 1024,
+            stream = false
+        };
+        var json = JsonSerializer.Serialize(obj);
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        request.Headers.Add("X-API-Key", _apiKey);
+        request.Headers.Add("anthropic-version", "2023-06-01");
+        using var client = new HttpClient();
+        var response = await client.SendAsync(request);
+        var str = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(str);
+        if (doc.RootElement.TryGetProperty("completion", out var c))
+            return c.GetString() ?? str;
+        return str;
+    }
+}

--- a/MacUkagaka.SHIORI/AIServices/GeminiService.cs
+++ b/MacUkagaka.SHIORI/AIServices/GeminiService.cs
@@ -1,0 +1,40 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+namespace MacUkagaka.SHIORI.AIServices;
+
+public class GeminiService : IAIService
+{
+    private readonly string _apiKey;
+    private readonly string _model;
+
+    public GeminiService(string apiKey, string model)
+    {
+        _apiKey = apiKey;
+        _model = string.IsNullOrEmpty(model) ? "gemini-pro" : model;
+    }
+
+    public async Task<string> GenerateResponseAsync(string prompt)
+    {
+        var endpoint = $"https://generativelanguage.googleapis.com/v1beta/models/{_model}:generateContent?key={_apiKey}";
+        var obj = new
+        {
+            contents = new[] { new { parts = new[] { new { text = prompt } } } }
+        };
+        var json = JsonSerializer.Serialize(obj);
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var client = new HttpClient();
+        var response = await client.SendAsync(request);
+        var str = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(str);
+        var root = doc.RootElement;
+        if (root.TryGetProperty("candidates", out var cand))
+        {
+            var text = cand[0].GetProperty("content").GetProperty("parts")[0].GetProperty("text").GetString();
+            return text ?? str;
+        }
+        return str;
+    }
+}

--- a/MacUkagaka.SHIORI/AIServices/IAIService.cs
+++ b/MacUkagaka.SHIORI/AIServices/IAIService.cs
@@ -1,0 +1,6 @@
+namespace MacUkagaka.SHIORI.AIServices;
+
+public interface IAIService
+{
+    Task<string> GenerateResponseAsync(string prompt);
+}

--- a/MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj
+++ b/MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/MacUkagaka.SHIORI/Models/SHIORIRequest.cs
+++ b/MacUkagaka.SHIORI/Models/SHIORIRequest.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace MacUkagaka.SHIORI.Models;
+
+public class SHIORIRequest
+{
+    public string? Id { get; set; }
+    public Dictionary<string,string> Headers { get; } = new();
+
+    public string? GetReference(int index)
+        => Headers.TryGetValue($"Reference{index}", out var v) ? v : null;
+
+    public static SHIORIRequest Parse(string text)
+    {
+        var req = new SHIORIRequest();
+        var lines = text.Split('\n');
+        foreach(var line in lines)
+        {
+            var trimmed = line.TrimEnd('\r');
+            if(string.IsNullOrWhiteSpace(trimmed)) continue;
+            var colon = trimmed.IndexOf(':');
+            if(colon > 0)
+            {
+                var key = trimmed.Substring(0, colon).Trim();
+                var val = trimmed[(colon + 1)..].Trim();
+                req.Headers[key] = val;
+                if(key == "ID") req.Id = val;
+            }
+        }
+        return req;
+    }
+}

--- a/MacUkagaka.SHIORI/Models/SHIORIResponse.cs
+++ b/MacUkagaka.SHIORI/Models/SHIORIResponse.cs
@@ -1,0 +1,20 @@
+using System.Text;
+
+namespace MacUkagaka.SHIORI.Models;
+
+public class SHIORIResponse
+{
+    public string Status { get; set; } = "200 OK";
+    public string Value { get; set; } = string.Empty;
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"SHIORI/3.0 {Status}");
+        sb.AppendLine("Charset: UTF-8");
+        sb.AppendLine("Content-Type: text/plain");
+        sb.AppendLine($"Value: {Value}");
+        sb.AppendLine();
+        return sb.ToString();
+    }
+}

--- a/MacUkagaka.SHIORI/Program.cs
+++ b/MacUkagaka.SHIORI/Program.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using MacUkagaka.SHIORI.AIServices;
+using MacUkagaka.SHIORI.Models;
+using MacUkagaka.SHIORI.Utils;
+
+namespace MacUkagaka.SHIORI;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configPath = args.Length > 0 ? args[0] : "config.json";
+        var config = new ConfigManager(configPath);
+        IAIService service = config.DefaultService switch
+        {
+            "claude" => new ClaudeService(config.GetApiKey("claude") ?? string.Empty, config.GetModel("claude") ?? string.Empty),
+            "gemini" => new GeminiService(config.GetApiKey("gemini") ?? string.Empty, config.GetModel("gemini") ?? string.Empty),
+            _ => new ChatGPTService(config.GetApiKey("chatgpt") ?? string.Empty, config.GetModel("chatgpt") ?? string.Empty)
+        };
+
+        while (true)
+        {
+            var requestText = ReadRequest();
+            if (requestText == null) break;
+
+            var request = SHIORIRequest.Parse(requestText);
+            string value = string.Empty;
+            if (request.Id == "OnBoot")
+            {
+                value = SakuraScriptBuilder.Simple("こんにちは！MacUkagakaです。");
+            }
+            else if (request.Id == "OnClose")
+            {
+                value = SakuraScriptBuilder.Simple("さようなら！");
+            }
+            else if (request.Id == "OnTalk")
+            {
+                var prompt = request.GetReference(0) ?? string.Empty;
+                value = SakuraScriptBuilder.Simple(await service.GenerateResponseAsync(prompt));
+            }
+
+            var response = new SHIORIResponse { Value = value };
+            Console.Write(response.ToString());
+        }
+    }
+
+    static string? ReadRequest()
+    {
+        var sb = new StringBuilder();
+        string? line;
+        while ((line = Console.ReadLine()) != null)
+        {
+            sb.AppendLine(line);
+            if (string.IsNullOrWhiteSpace(line))
+                break;
+        }
+        if (sb.Length == 0)
+            return null;
+        return sb.ToString();
+    }
+}

--- a/MacUkagaka.SHIORI/Utils/ConfigManager.cs
+++ b/MacUkagaka.SHIORI/Utils/ConfigManager.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace MacUkagaka.SHIORI.Utils;
+
+public class ConfigManager
+{
+    private readonly JsonNode _root;
+
+    public ConfigManager(string path)
+    {
+        var json = File.ReadAllText(path);
+        _root = JsonNode.Parse(json)!;
+    }
+
+    public string DefaultService => _root["ai_settings"]?["default_service"]?.ToString() ?? "chatgpt";
+
+    public string? GetApiKey(string service) => _root["ai_settings"]?[service]? ["api_key"]?.ToString();
+
+    public string? GetModel(string service) => _root["ai_settings"]?[service]? ["model"]?.ToString();
+}

--- a/MacUkagaka.SHIORI/Utils/SakuraScriptBuilder.cs
+++ b/MacUkagaka.SHIORI/Utils/SakuraScriptBuilder.cs
@@ -1,0 +1,7 @@
+namespace MacUkagaka.SHIORI.Utils;
+
+public static class SakuraScriptBuilder
+{
+    public static string Simple(string text)
+        => $"\\h\\s[0]{text}\\e";
+}

--- a/MacUkagaka.SHIORI/config.json
+++ b/MacUkagaka.SHIORI/config.json
@@ -1,0 +1,17 @@
+{
+  "ai_settings": {
+    "default_service": "chatgpt",
+    "chatgpt": {
+      "api_key": "",
+      "model": "gpt-3.5-turbo"
+    },
+    "claude": {
+      "api_key": "",
+      "model": "claude-instant-1"
+    },
+    "gemini": {
+      "api_key": "",
+      "model": "gemini-pro"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -92,3 +92,16 @@ Unix系では `./geminicli.sh`、Windowsでは `geminicli.bat` を実行する�
 
 API キーを環境変数 `GEMINI_API_KEY` に設定している場合は `--api-key` オプションを省略できます。
 実行時にコンソール操作の許可を確認するプロンプトが表示され、`y` を入力すると送信が行われます。
+
+## MacUkagaka.SHIORI (.NET Core)
+
+`MacUkagaka.SHIORI` ディレクトリには、macOS でも動作する C# 製 SHIORI の実装を配置しています。
+以下のようにビルドして実行できます。
+
+```bash
+dotnet build MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj
+cd MacUkagaka.SHIORI
+dotnet run
+```
+
+設定ファイル `config.json` に各 AI サービスの API キーとモデル名を記述してください。


### PR DESCRIPTION
## Summary
- create `MacUkagaka.SHIORI` console project targeting .NET 8
- implement ChatGPT/Claude/Gemini AI services
- provide simple SHIORI request/response handling and utilities
- add example configuration file
- document the new project in `README.md`

## Testing
- `dotnet build MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj` *(fails: unable to access NuGet due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68772f53888083228daeff49ebe197e5