### PR TITLE
Implement MacUkagaka .NET Core SHIORI

### DIFF
--- a/MacUkagaka/README.md
+++ b/MacUkagaka/README.md
@@ -34,7 +34,7 @@ swift build
 
 ## 使用方法
 
-1. ゴーストとシェルデータを配置
+1. ゴーストとシェルデータを配置し、`ghost/master/descript.txt` の `shiori` 行を `MacUkagaka.SHIORI.dll` に変更
 2. アプリケーションを実行
 
 ```bash


### PR DESCRIPTION
## Summary
- support launching `MacUkagaka.SHIORI.dll` from the Swift side
- document how to switch to the new SHIORI in `descript.txt`

## Testing
- `dotnet build MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj` *(fails: proxy 403)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6877382fef2c8322a7c59927fac5f1bc