### PR TITLE
Fix MacUkagaka display and AI loop

### DIFF
--- a/MacUkagaka.SHIORI/Program.cs
+++ b/MacUkagaka.SHIORI/Program.cs
@@ -37,6 +37,11 @@ class Program
             {
                 value = SakuraScriptBuilder.Simple("さようなら！");
             }
+            else if (request.Id == "OnSecondChange")
+            {
+                Console.Write(new SHIORIResponse { Value = string.Empty }.ToString());
+                continue;
+            }
             else if (request.Id == "OnTalk")
             {
                 var prompt = request.GetReference(0) ?? string.Empty;

--- a/MacUkagaka/MacUkagaka/CharacterWindowController.swift
+++ b/MacUkagaka/MacUkagaka/CharacterWindowController.swift
@@ -39,6 +39,7 @@ class CharacterWindowController: NSWindowController {
         window.backgroundColor = NSColor.clear
         window.isOpaque = false
         window.level = .floating
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         window.isMovableByWindowBackground = true
         window.acceptsMouseMovedEvents = true
         window.ignoresMouseEvents = false
@@ -54,6 +55,7 @@ class CharacterWindowController: NSWindowController {
         characterImageView.imageScaling = .scaleNone
         characterImageView.imageAlignment = .alignCenter
         characterImageView.wantsLayer = true
+        characterImageView.layer?.backgroundColor = NSColor.clear.cgColor
         
         let trackingArea = NSTrackingArea(
             rect: characterImageView.bounds,


### PR DESCRIPTION
## Summary
- prevent OnSecondChange responses from causing endless "元気です" output
- keep character window visible across spaces and ensure transparent background

## Testing
- `dotnet build MacUkagaka.SHIORI/MacUkagaka.SHIORI.csproj -c Release`
- `swift build --product MacUkagaka` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_6877738437dc8322b770ebf42bf15696