### PR TITLE
Consolidate license notices

### DIFF
--- a/THIRD-PARTY-LIBRARIES.md
+++ b/THIRD-PARTY-LIBRARIES.md
@@ -1,93 +1,29 @@
-# 使用ライブラリ一覧
-本ゴーストは以下のライブラリを使用しています。
-が、本ゴーストは現状のまま提供され、
-本ゴーストの利用によりあなたが何かしらの損害を受けた場合も
-以下のライブラリ製作者はもちろん、
-本ゴースト製作者も責任は負えませんのでご了承ください。
+# THIRD-PARTY LIBRARIES / サードパーティライブラリ
 
+This project uses the third-party libraries listed below. The software is provided "AS IS" without warranty of any kind. The authors of these libraries and the authors of this project shall not be liable for any damages arising from its use.
 
-## テンプレートゴースト
-rosalind_0_1_6_0_template  
-著作権表示: Copyright (c) 2019 as-is-prog
+本プロジェクトでは以下のサードパーティライブラリを利用しています。本ソフトウェアは現状のまま提供され、使用に伴い生じたいかなる損害に対しても、ライブラリの作者および本プロジェクトの作者は責任を負いません。
 
-## シェル
-ボトル猫様制作の「pink」を使用しています。  
-http://catbottle.sakura.ne.jp/  
-著作権表示: Copyright (c) ボトル猫
+## Template Ghost / テンプレートゴースト
+- **rosalind_0_1_6_0_template**  © 2019 as-is-prog
 
-## 使用ライブラリとそのライセンス
-### 修正BSDライセンス
-#### SHIOLINK.dll
-著作権表示: Copyright (c) どっとステーション
+## Shell / シェル
+- **"pink"** by ボトル猫 / Bottleneck  
+  <http://catbottle.sakura.ne.jp/>
+
+## Libraries and Licenses / 使用ライブラリとそのライセンス
+
+### BSD 2-Clause License / 修正BSDライセンス
+- **SHIOLINK.dll**  © どっとステーション
 
 ### MIT License
-#### rosalind
-著作権表示: Copyright (c) 2019 as-is-prog
-
-#### Fody
-Costura.Fody, Fody
-
-著作権表示: Copyright (c) Simon Cropp and contributors
-
-#### .NET Foundation and Contributors
-<details>
-<summary>一覧</summary>
-System.Collection.Immutable,
-System.Reflection.Metadata,
-System.Runtime.CompilerServices.Unsafe,
-System.Text.Encoding.CodePages,
-System.Threading.Tasks.Extensions,
-System.ValueTuple
-</details>
-
-著作権表示: Copyright (c) .NET Foundation and Contributors
+- **rosalind**  © 2019 as-is-prog
+- **Fody**, **Costura.Fody**  © Simon Cropp and contributors
+- **.NET Foundation and Contributors**  (System.Collection.Immutable, System.Reflection.Metadata, System.Runtime.CompilerServices.Unsafe, System.Text.Encoding.CodePages, System.Threading.Tasks.Extensions, System.ValueTuple)
+- **Newtonsoft.Json**  © 2007 James Newton-King
 
 ### Microsoft .NET Library License
-<details>
-<summary>一覧</summary>
-Microsoft.CodeAnalysis.Analyzers,
-Microsoft.CodeAnalysis.Common,
-Microsoft.CodeAnalysis.CSharp,
-Microsoft.CodeAnalysis.CSharp.Scripting,
-Microsoft.CodeAnalysis.Scripting.Common,
-System.AppContext,
-System.Collections,
-System.Collections.Concurrent,
-System.Console,
-System.Diagnostics.Debug,
-System.Diagnostics.FileVersionInfo,
-System.Diagnostics.StackTrace,
-System.Diagnostics.Tools,
-System.Dynamic.Runtime,
-System.Globalization,
-System.IO,
-System.IO.Compression,
-System.IO.FileSystem,
-System.IO.FileSystem.Primitives,
-System.Linq,
-System.Linq.Expressions,
-System.Reflection,
-System.Reflection.Extensions,
-System.Resources.ResourceManager,
-System.Runtime,
-System.Runtime.Extensions,
-System.Runtime.InteropServices,
-System.Runtime.Numerics,
-System.Security.Cryptography.Algorithms,
-System.Security.Cryptography.Encoding,
-System.Security.Cryptography.Primitives,
-System.Security.Cryptography.X509Certificates,
-System.Text.Encoding,
-System.Text.Encoding.Extensions,
-System.Threading,
-System.Threading.Tasks,
-System.Threading.Tasks.Parallel,
-System.Threading.Thread,
-System.Xml.ReaderWriter,
-System.Xml.XDocument,
-System.Xml.XmlDocument,
-System.Xml.XPath
-</details>
+Microsoft.CodeAnalysis.Analyzers, Microsoft.CodeAnalysis.Common, Microsoft.CodeAnalysis.CSharp, Microsoft.CodeAnalysis.CSharp.Scripting, Microsoft.CodeAnalysis.Scripting.Common, System.AppContext, System.Collections, System.Collections.Concurrent, System.Console, System.Diagnostics.Debug, System.Diagnostics.FileVersionInfo, System.Diagnostics.StackTrace, System.Diagnostics.Tools, System.Dynamic.Runtime, System.Globalization, System.IO, System.IO.Compression, System.IO.FileSystem, System.IO.FileSystem.Primitives, System.Linq, System.Linq.Expressions, System.Reflection, System.Reflection.Extensions, System.Resources.ResourceManager, System.Runtime, System.Runtime.Extensions, System.Runtime.InteropServices, System.Runtime.Numerics, System.Security.Cryptography.Algorithms, System.Security.Cryptography.Encoding, System.Security.Cryptography.Primitives, System.Security.Cryptography.X509Certificates, System.Text.Encoding, System.Text.Encoding.Extensions, System.Threading, System.Threading.Tasks, System.Threading.Tasks.Parallel, System.Threading.Thread, System.Xml.ReaderWriter, System.Xml.XDocument, System.Xml.XmlDocument, System.Xml.XPath
 
-### Newtonsoft.Json
-著作権表示: Copyright (c) 2007 James Newton-King
+## Original Source Notices / 自作コードの著作権表記
+© eightman 2005-2025, Furin-lab All Rights Reserved. The Swift and C# source files in this repository contain this notice at the top of each file.


### PR DESCRIPTION
## Summary
- rewrite `THIRD-PARTY-LIBRARIES.md` in Japanese and English
- gather broad license notices for all third party components and original code

## Testing
- `swift test` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_687bb212232c8322b3a3d20dae8885c5