### PR TITLE
Add clang-format and SwiftFormat with CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortIfStatementsOnASingleLine: false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,27 @@
+name: clang-format
+on:
+  pull_request:
+    paths:
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.mm'
+      - '**/*.h'
+      - '**/*.hpp'
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: clang-format check
+        uses: doozyx/clang-format-lint-action@v1.4
+        with:
+          clangFormatVersion: 17
+          source: './'
+          style: file
+          inplace: false

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -1,0 +1,22 @@
+name: swiftformat
+on:
+  pull_request:
+    paths:
+      - '**/*.swift'
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  lint:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run SwiftFormat
+        uses: mtgto/swift-format-action@main
+        with:
+          configuration_file: '.swiftformat'
+      - name: Fail if diffs exist
+        run: git diff --exit-code

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,4 @@
+--swiftversion 5.10
+--indent 4
+--maxwidth 120
+--exclude Pods

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # AI何かちゃん & MacUkagaka
+![clang-format](https://github.com/eightman999/AINanikaAIChan/actions/workflows/clang-format.yml/badge.svg)
+![swiftformat](https://github.com/eightman999/AINanikaAIChan/actions/workflows/swiftformat.yml/badge.svg)
 
 ## プロジェクト概要
 
@@ -104,3 +106,11 @@ dotnet run
 ```
 
 設定ファイル `config.json` に各 AI サービスの API キーとモデル名を記述してください。
+
+## フォーマットツール
+
+以下のコマンドで `clang-format` と `swiftformat` をインストールすると、ローカルでも CI と同じ設定でコードを整形できます。
+
+```bash
+brew install clang-format swiftformat
+```


### PR DESCRIPTION
## Summary
- add `.clang-format` and `.swiftformat` configuration
- add clang-format GitHub Action
- add SwiftFormat GitHub Action
- show badges and mention format tools in README

## Testing
- `swift test -v` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_687f8f287d888322b569b552c7e44911