### PR TITLE
Update shared FMO to SakuraUnicode format

### DIFF
--- a/CharacterWindowController.swift
+++ b/CharacterWindowController.swift
@@ -45,7 +45,7 @@ class CharacterWindowController: NSWindowController {
         loadInitialSurface()
 
         // Initialize shared memory and start periodic updates.
-        fmo = SharedFMO()
+        fmo = SharedFMO(ghostPath: ghostManager.path)
         fmo?.start(stateProvider: { [weak self] in
             let surface = Int32(self?.currentSurface ?? 0)
             let talk = (self?.isProcessingScript ?? false) ? Int32(1) : Int32(0)

--- a/GhostManager.swift
+++ b/GhostManager.swift
@@ -751,4 +751,9 @@ extension GhostManager {
     var keroName: String {
         return ghostInfo?.keroName ?? "うにゅう"
     }
+
+    /// ゴーストのルートディレクトリパスを返す。
+    var path: String {
+        return ghostPath
+    }
 }

--- a/MacUkagaka/MacUkagaka/SharedFMO.swift
+++ b/MacUkagaka/MacUkagaka/SharedFMO.swift
@@ -1,83 +1,107 @@
-import Foundation
 import Darwin
+import Foundation
 
-/// Shared memory manager using mmap for Fake Memory Object (FMO).
+/// Manager for Fake Memory Object (FMO) compatible shared memory.
 class SharedFMO {
-    /// App Group identifier used for the shared container.
-    static let groupID = "group.com.example.sstp"
-    /// Name of the shared binary file.
-    private let fileName = "SharedFmo.bin"
-    /// File descriptor for the mapped file.
-    private var fileDescriptor: Int32 = -1
-    /// Pointer to the mapped memory region.
-    private var mappedPointer: UnsafeMutablePointer<FMOData>?
-    /// Timer for periodic updates.
-    private var updateTimer: Timer?
+  /// App Group identifier used for the shared container.
+  static let groupID = "group.com.example.sstp"
 
-    /// Data layout stored in the shared memory.
-    struct FMOData {
-        var surfaceID: Int32
-        var talkStatus: Int32
-    }
+  /// FMO buffer size defined by the specification (64KB).
+  private let FMOSize = 0x10000
 
-    /// Initializes the shared memory mapping under the App Group container.
-    init?() {
-        guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Self.groupID) else {
-            return nil
-        }
-        let sstpDir = containerURL.appendingPathComponent("sstp", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: sstpDir, withIntermediateDirectories: true, attributes: nil)
-        } catch {
-            return nil
-        }
-        let fileURL = sstpDir.appendingPathComponent(fileName)
-        fileDescriptor = open(fileURL.path, O_RDWR | O_CREAT, 0o600)
-        guard fileDescriptor != -1 else { return nil }
-        let size = MemoryLayout<FMOData>.stride
-        if ftruncate(fileDescriptor, off_t(size)) != 0 {
-            close(fileDescriptor)
-            return nil
-        }
-        let ptr = mmap(nil, size, PROT_READ | PROT_WRITE, MAP_SHARED, fileDescriptor, 0)
-        guard ptr != MAP_FAILED else {
-            close(fileDescriptor)
-            return nil
-        }
-        mappedPointer = ptr?.bindMemory(to: FMOData.self, capacity: 1)
-    }
+  /// Shared memory file name defined by the Sakura Unicode spec.
+  private let fileName = "SakuraUnicode"
 
-    deinit {
-        stop()
-    }
+  /// Named semaphore used for write locking.
+  private let mutexName = "/aink_fmo_mutex"
 
-    /// Starts periodic updates with the provided state provider.
-    func start(stateProvider: @escaping () -> (Int32, Int32)) {
-        updateTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            let (surface, talking) = stateProvider()
-            self?.write(surfaceID: surface, talk: talking)
-        }
-    }
+  private var fileDescriptor: Int32 = -1
+  private var mappedPointer: UnsafeMutableRawPointer?
+  private var updateTimer: Timer?
 
-    /// Stops updates and unmaps the memory.
-    func stop() {
-        updateTimer?.invalidate()
-        updateTimer = nil
-        if let ptr = mappedPointer {
-            munmap(ptr, MemoryLayout<FMOData>.stride)
-            mappedPointer = nil
-        }
-        if fileDescriptor != -1 {
-            close(fileDescriptor)
-            fileDescriptor = -1
-        }
-    }
+  private let ghostPath: String
+  private let ghostID: String
 
-    /// Writes the latest surface ID and talk status into the shared memory.
-    private func write(surfaceID: Int32, talk: Int32) {
-        guard let ptr = mappedPointer else { return }
-        ptr.pointee.surfaceID = surfaceID
-        ptr.pointee.talkStatus = talk
-        msync(ptr, MemoryLayout<FMOData>.stride, MS_ASYNC)
+  init?(ghostPath: String) {
+    self.ghostPath = ghostPath
+    self.ghostID = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      .padding(toLength: 32, withPad: "0", startingAt: 0)
+
+    guard
+      let containerURL = FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: Self.groupID)
+    else {
+      return nil
     }
+    let fileURL = containerURL.appendingPathComponent(fileName)
+    fileDescriptor = open(fileURL.path, O_RDWR | O_CREAT, 0o600)
+    if fileDescriptor == -1 { return nil }
+    if ftruncate(fileDescriptor, off_t(FMOSize)) != 0 {
+      close(fileDescriptor)
+      return nil
+    }
+    let ptr = mmap(nil, FMOSize, PROT_READ | PROT_WRITE, MAP_SHARED, fileDescriptor, 0)
+    if ptr == MAP_FAILED {
+      close(fileDescriptor)
+      return nil
+    }
+    mappedPointer = ptr
+    mappedPointer?.storeBytes(of: UInt32(FMOSize).littleEndian, as: UInt32.self)
+  }
+
+  deinit { stop() }
+
+  func start(stateProvider: @escaping () -> (Int32, Int32)) {
+    updateTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+      guard let self else { return }
+      let (surface, talk) = stateProvider()
+      self.write(surfaceID: surface, talk: talk)
+    }
+  }
+
+  func stop() {
+    updateTimer?.invalidate()
+    updateTimer = nil
+    if let ptr = mappedPointer {
+      munmap(ptr, FMOSize)
+      mappedPointer = nil
+    }
+    if fileDescriptor != -1 {
+      close(fileDescriptor)
+      fileDescriptor = -1
+    }
+  }
+
+  private func write(surfaceID: Int32, talk: Int32) {
+    let timestamp = UInt64(Date().timeIntervalSince1970)
+    let lines = [
+      "\(ghostID).path\u{1}\(ghostPath)",
+      "\(ghostID).surface\u{1}\(surfaceID)",
+      "\(ghostID).talk\u{1}\(talk)",
+      "timestamp\u{1}\(timestamp)",
+    ]
+    writeLines(lines)
+  }
+
+  private func writeLines(_ lines: [String]) {
+    guard let base = mappedPointer else { return }
+    let sem = sem_open(mutexName, O_CREAT, 0o600, 1)
+    guard sem != nil else { return }
+    defer { sem_close(sem) }
+    sem_wait(sem)
+
+    var cursor = base.advanced(by: 4)
+    for line in lines {
+      var bytes = Array(line.utf8)
+      bytes.append(0x0D)
+      bytes.append(0x0A)
+      bytes.withUnsafeBytes { ptr in
+        memcpy(cursor, ptr.baseAddress, ptr.count)
+      }
+      cursor = cursor.advanced(by: bytes.count)
+    }
+    cursor.storeBytes(of: UInt8(0), as: UInt8.self)
+    msync(base, FMOSize, MS_ASYNC)
+    sem_post(sem)
+  }
 }


### PR DESCRIPTION
## Summary
- expose GhostManager path property
- start SharedFMO with ghost path and implement SakuraUnicode layout
- write surface and talk state lines guarded by semaphore

## Testing
- `swift-format format --in-place MacUkagaka/MacUkagaka/SharedFMO.swift`

------
https://chatgpt.com/codex/tasks/task_e_687fa1d179ac832284264dfd59910c19